### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   def index  
-      # @items = Item.all
-      # 今後のプルリクエストで拝見したいファイルが差分として上がってこない可能性があるので
+    @items = Item.all.order(id: "DESC")
+    
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,6 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   def index  
     @items = Item.all.order(id: "DESC")
-    
   end
 
   def new
@@ -11,9 +10,8 @@ class ItemsController < ApplicationController
 
   
     def create
-      
       @item = Item.new(item_params)
-
+    
       if @item.save
         redirect_to root_path
       else

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,13 +126,17 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+        
+          <%= image_tag item.image, class: "item-img" %> 
 
           <%# 商品が売れていればsold outを表示しましょう %>
+          <%# sold outの表示は、商品購入機能実装した後に追加で実装をします。
+          カリキュラム、実装に悩んだときのヒント〜商品一覧表示機能〜%>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
@@ -141,10 +145,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,13 +157,15 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
+      
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      
+      <%if @items == nil%>
       <li class='list'>
         <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img"  %>
         <div class='item-info'>
           <h3 class='item-name'>
             商品を出品してね！
@@ -174,12 +180,13 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+      <% end %>%
+      
       <%# /商品がない場合のダミー %>
     </ul>
   </div>
   <%# /商品一覧 %>
-  <%# 多分これ　<%= image_tag message.image, class: 'message-image' if message.image.attached? %> %>
+  
 </div>
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -162,7 +162,8 @@
 
       <%# 商品がない場合のダミー %>
       
-      <%if @items == nil%>
+      <%if @items[0] == nil%>
+      <%# あとで消すのでコメントアウト残しておきたいです。[０]でないとnilにはならないbinding.pryで見ると[]は届いていてる、だから添字まで書いてあげる[0] %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img"  %>
@@ -180,7 +181,7 @@
         </div>
         <% end %>
       </li>
-      <% end %>%
+      <% end %>
       
       <%# /商品がない場合のダミー %>
     </ul>


### PR DESCRIPTION
- 出品した商品の一覧表示ができていること
- 上から、出品された日時が新しい順に表示されること
- 「画像/価格/商品名」の3つの情報について表示できていること
- 売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
https://gyazo.com/6334cdc79f174ca9ffe49588aa7ba105

- ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/4889b2fc9522e7da9dd34d9bdce297b8
